### PR TITLE
[MBL-96] Iconコンポーネントを作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "postcss": "^8.4.13",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
+        "react-icons": "^4.4.0",
         "react-query": "^3.39.0",
         "react-redux": "^8.0.2",
         "react-scripts": "5.0.0",
@@ -30062,6 +30063,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -59585,6 +59594,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "postcss": "^8.4.13",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
+    "react-icons": "^4.4.0",
     "react-query": "^3.39.0",
     "react-redux": "^8.0.2",
     "react-scripts": "5.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { Header } from './components/organisms/Header/Header';
 import { Footer } from './components/organisms/Footer/Footer';
 import { ImageList } from './components/organisms/ImageList/ImageList';
 import { useQueryWrapper } from './helper/reactQueryWrapper';
+import { Icon } from './components/atoms/Icon/Icon';
 
 export const App = () => {
     const count = useAppSelector((state) => state.counter.value)
@@ -25,6 +26,7 @@ export const App = () => {
       <Header />
       <div className={css({ gridArea: "left", padding: "40px 20px" })}>
         <MenuNav title="探す" menus={[{title: "色から探す"}, {title: "アイテムから探す"}, {title: "ジャンルから探す"}, {title: "ユーザーを探す"}]} />
+        <Icon name="AiFillCar" color="#900" size={100} />
       </div>
       <div className={css({ gridArea: "content" })}>
         {res.data?.message && <ImageList images={res.data.message} />}

--- a/src/components/atoms/Icon/Icon.tsx
+++ b/src/components/atoms/Icon/Icon.tsx
@@ -1,0 +1,15 @@
+import * as icons from "react-icons/ai"
+import {IconBaseProps} from "react-icons"
+
+type IconProps = IconBaseProps & {
+  name: keyof typeof icons
+}
+
+/**
+ * アイコンはここから探すことができます。
+ * https://react-icons.github.io/react-icons/icons?name=ai
+ */
+export const Icon: React.FC<IconProps> = ({name, ...props}) => {
+  const IconCore = icons[name]
+  return <IconCore {...props} />
+}


### PR DESCRIPTION
### JIRA

https://mabell.atlassian.net/browse/MBL-96

### 概要

- [ ] `Icon`コンポーネントを追加

<img width="234" alt="image" src="https://user-images.githubusercontent.com/35861846/176992030-b08d73d4-ca66-4d71-93fa-fc78a70ff117.png">

**使い方**

- `name` propsに、アイコンの名前を渡すことで、そのアイコンを表示することができます。
- アイコンの名前は[こちら](https://react-icons.github.io/react-icons/icons?name=ai)で探すことができます。

```tsx
<Icon name="AiFillCar" color="#900" size={100} />
```

### 関連リンク

https://zenn.dev/taichifukumoto/articles/how-to-use-react-icons
