### PR TITLE
[MBL-94] Cardコンポーネントのビジュアルを追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,18 +24,18 @@ export const App = () => {
   return (
     <div className={styles.container}>
       <Header />
-      <div className={css({ gridArea: "left", padding: "40px 20px" })}>
+      <div className={css({ gridArea: "left", padding: "40px 20px", background: "#EEE" })}>
         <MenuNav title="探す" menus={[{title: "色から探す"}, {title: "アイテムから探す"}, {title: "ジャンルから探す"}, {title: "ユーザーを探す"}]} />
-        <Icon name="AiFillCar" color="#900" size={100} />
+        <Icon name="BsCart" color="#900" size={100} />
       </div>
-      <div className={css({ gridArea: "content" })}>
+      <div className={css({ gridArea: "content", background: "#EEE" })}>
         {res.data?.message && <ImageList images={res.data.message} />}
         <User />
         <Button label="カウントアップ" onClick={() => dispatch(increment())} />
         <Button label="カウントダウン" onClick={() => dispatch(decrement())} />
         <h1>{count}</h1>
       </div>
-      <div className={css({ gridArea: "right" })}>Right</div>
+      <div className={css({ gridArea: "right", background: "#EEE" })}>Right</div>
       <Footer />
     </div>
   );

--- a/src/components/atoms/Icon/Icon.tsx
+++ b/src/components/atoms/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import * as icons from "react-icons/ai"
+import * as icons from "react-icons/bs"
 import {IconBaseProps} from "react-icons"
 
 type IconProps = IconBaseProps & {
@@ -7,7 +7,7 @@ type IconProps = IconBaseProps & {
 
 /**
  * アイコンはここから探すことができます。
- * https://react-icons.github.io/react-icons/icons?name=ai
+ * https://react-icons.github.io/react-icons/icons?name=bs
  */
 export const Icon: React.FC<IconProps> = ({name, ...props}) => {
   const IconCore = icons[name]

--- a/src/components/molecules/Card/Card.tsx
+++ b/src/components/molecules/Card/Card.tsx
@@ -1,20 +1,38 @@
 import { css } from "@emotion/css"
 
-type CardProps = {
-  src?: string
-  alt?: string
+export type CardProps = {
+    src?: string
+    alt?: string
+    children?: React.ReactNode
 }
 
-export const Card = ({src, alt}: CardProps) => {
-  return (
-    <img src={src} alt={alt} className={styles.container} />
-  )
+
+const Image: React.FC<Pick<CardProps, "src" | "alt">> = ({src, alt}) => {
+    if (src) {
+        return <img src={src} alt={alt} className={styles.image} />
+    }
+    return <div className={styles.image}>no image</div>
+}
+
+export const Card = ({src, alt, children}: CardProps) => {
+    return (
+        <div className={styles.container}>
+            <Image src={src} alt={alt} />
+            {children}
+        </div>
+    )
 }
 
 const styles = {
-  container: css({
-    height: 200,
-    width: 200,
-    objectFit: "cover"
-  })
+    container: css({
+        borderRadius: 10,
+        height: 250,
+        backgroundColor: "#FFF",
+    }),
+    image: css({
+        height: 210,
+        width: 300,
+        objectFit: "cover",
+        borderRadius: "10px 10px 0 0",
+    }),
 }

--- a/src/components/organisms/ImageList/ImageList.tsx
+++ b/src/components/organisms/ImageList/ImageList.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/css"
-import { Card } from "../../molecules/Card/Card"
+import { PostCard } from "../PostCard/PostCard"
 
 type ImageListProps = {
   images: Array<string>
@@ -8,7 +8,7 @@ type ImageListProps = {
 export const ImageList = ({images}: ImageListProps) => {
   return (
     <div className={styles.container}>
-      {images.map((image, index) => <Card key={index} src={image} />)}
+      {images.map((image, index) => <PostCard key={index} src={image} />)}
     </div>
   )
 }
@@ -16,8 +16,9 @@ export const ImageList = ({images}: ImageListProps) => {
 const styles = {
   container: css({
     display: "grid",
-    gridAutoRows: "200px",
-    gridTemplateColumns: "repeat(auto-fill, 200px)",
-    gap: 10,
+    gridAutoRows: "250px",
+    gridTemplateColumns: "repeat(auto-fill, 300px)",
+    columnGap: 20,
+    rowGap: 30,
   })
 }

--- a/src/components/organisms/PostCard/PostCard.tsx
+++ b/src/components/organisms/PostCard/PostCard.tsx
@@ -1,0 +1,49 @@
+import { css } from "@emotion/css";
+import { Icon } from "../../atoms/Icon/Icon";
+import { Card, CardProps } from "../../molecules/Card/Card"
+
+type PostCardProps = CardProps & {
+    onLike?: () => void
+    onBookmark?: () => void
+    postUserId?: string
+};
+
+export const PostCard: React.FC<PostCardProps> = (props) => {
+    return (
+        <Card {...props}>
+            <div className={styles.cardFooter}>
+                <div className={styles.left}>
+                    <Icon name="BsCircleFill" color="#C4C4C4" />
+                    <span>user_name</span>
+                    <span>イエベ春</span>
+                </div>
+                <div className={styles.right}>
+                    <Icon name="BsHeart" color="#C4C4C4" />
+                    <Icon name="BsBookmarkFill" color="#C4C4C4" />
+                </div>
+            </div>
+        </Card>
+    )
+}
+
+const styles = {
+    cardFooter: css({
+        display: "flex",
+        height: 40,
+        alignItems: "center",
+        padding: "0 10px"
+    }),
+    left: css({
+        display: "flex",
+        alignItems: "center",
+        gap: 4,
+        "> span": {
+            fontSize: 10
+        },
+    }),
+    right: css({
+        display: "flex",
+        marginLeft: "auto",
+        gap: 10,
+    })
+}


### PR DESCRIPTION
### JIRA
https://mabell.atlassian.net/browse/MBL-94

### 概要

- [ ] `Card`コンポーネントのスタイルを修正
- [ ] `Card`コンポーネントを拡張した、投稿一覧用の`PostCard`コンポーネントを追加
- [ ] `Icon`コンポーネントのアイコンセットを変更(Ant Design Icons (ai) -> Bootstrap Icons (bs))

<img width="318" alt="image" src="https://user-images.githubusercontent.com/35861846/176994717-3cdaf84b-e4e6-4bbe-8e99-1e80300be969.png">
